### PR TITLE
Implement basic API request functionality

### DIFF
--- a/Controls/AuthInput/AuthInput.xaml.cs
+++ b/Controls/AuthInput/AuthInput.xaml.cs
@@ -1,0 +1,17 @@
+using System.Windows.Controls;
+
+namespace Controls.AuthInput{
+    public partial class AuthInput : UserControl{
+        public AuthInput(){
+            InitializeComponent();
+            AuthComboBox.SelectedIndex = 0;
+        }
+        public string AuthType{
+            get => ((ComboBoxItem)AuthComboBox.SelectedItem)?.Content?.ToString() ?? "None";
+        }
+        public string TokenPath{
+            get => TokenPathTextBox.Text;
+            set => TokenPathTextBox.Text = value;
+        }
+    }
+}

--- a/Controls/BodyInput/BodyInput.xaml.cs
+++ b/Controls/BodyInput/BodyInput.xaml.cs
@@ -1,0 +1,19 @@
+using System.Windows.Controls;
+using Utils;
+
+namespace Controls.BodyInput{
+    public partial class BodyInput : UserControl{
+        public BodyInput(){
+            InitializeComponent();
+        }
+        public bool TryGetBody(out string body, out string error){
+            body = string.Empty;
+            error = string.Empty;
+            if(string.IsNullOrWhiteSpace(BodyTextBox.Text)) return true;
+            if(!JsonUtils.TryFormatJson(BodyTextBox.Text, out string formatted, out error)) return false;
+            body = formatted;
+            BodyTextBox.Text = formatted;
+            return true;
+        }
+    }
+}

--- a/Controls/HeaderInput/HeaderInput.xaml.cs
+++ b/Controls/HeaderInput/HeaderInput.xaml.cs
@@ -1,0 +1,26 @@
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Windows.Controls;
+using Utils;
+
+namespace Controls.HeaderInput{
+    public partial class HeaderInput : UserControl{
+        public HeaderInput(){
+            InitializeComponent();
+        }
+        public bool TryGetHeaders(out Dictionary<string, string> headers, out string error){
+            headers = new Dictionary<string, string>();
+            error = "";
+            if(string.IsNullOrWhiteSpace(HeadersTextBox.Text)) return true;
+            if(!JsonUtils.TryFormatJson(HeadersTextBox.Text, out string formatted, out error)) return false;
+            try{
+                headers = JsonSerializer.Deserialize<Dictionary<string, string>>(formatted) ?? new Dictionary<string, string>();
+                HeadersTextBox.Text = formatted;
+                return true;
+            }catch(JsonException ex){
+                error = ex.Message;
+                return false;
+            }
+        }
+    }
+}

--- a/Controls/MethodSelecter/MethodSelecter.xaml.cs
+++ b/Controls/MethodSelecter/MethodSelecter.xaml.cs
@@ -1,0 +1,13 @@
+using System.Windows.Controls;
+
+namespace Controls.MethodSelecter{
+    public partial class MethodSelecter : UserControl{
+        public MethodSelecter(){
+            InitializeComponent();
+            MethodComboBox.SelectedIndex = 0;
+        }
+        public string Method{
+            get => ((ComboBoxItem)MethodComboBox.SelectedItem)?.Content?.ToString() ?? "GET";
+        }
+    }
+}

--- a/Controls/ResponseOutput/ResponseOutput.xaml
+++ b/Controls/ResponseOutput/ResponseOutput.xaml
@@ -1,0 +1,11 @@
+<UserControl x:Class="Controls.ResponseOutput.ResponseOutput"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    Height="Auto" Width="Auto">
+    <Grid Margin="10">
+        <StackPanel>
+            <TextBlock Text="Response:"/>
+            <TextBox x:Name="ResponseTextBox" Height="150" AcceptsReturn="True" VerticalScrollBarVisibility="Auto" IsReadOnly="True" TextWrapping="Wrap"/>
+        </StackPanel>
+    </Grid>
+</UserControl>

--- a/Controls/ResponseOutput/ResponseOutput.xaml.cs
+++ b/Controls/ResponseOutput/ResponseOutput.xaml.cs
@@ -1,0 +1,13 @@
+using System.Windows.Controls;
+
+namespace Controls.ResponseOutput{
+    public partial class ResponseOutput : UserControl{
+        public ResponseOutput(){
+            InitializeComponent();
+        }
+        public string Text{
+            get => ResponseTextBox.Text;
+            set => ResponseTextBox.Text = value;
+        }
+    }
+}

--- a/Controls/UrlInput/UrlInput.xaml.cs
+++ b/Controls/UrlInput/UrlInput.xaml.cs
@@ -1,0 +1,13 @@
+using System.Windows.Controls;
+
+namespace Controls.UrlInput{
+    public partial class UrlInput : UserControl{
+        public UrlInput(){
+            InitializeComponent();
+        }
+        public string Url{
+            get => UrlTextBox.Text;
+            set => UrlTextBox.Text = value;
+        }
+    }
+}

--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -13,6 +13,7 @@
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="*"/>
             <RowDefinition Height="Auto"/>
+            <RowDefinition Height="2*"/>
         </Grid.RowDefinitions>
         <controls:UrlInput x:Name="UrlInputControl" Grid.Row="0" Margin="0,0,0,5"/>
         <StackPanel Orientation="Horizontal" Grid.Row="1" Margin="0,0,0,5">
@@ -21,6 +22,7 @@
         </StackPanel>
         <controls:HeaderInput x:Name="HeaderInputControl" Grid.Row="2" Margin="0,0,0,5"/>
         <controls:BodyInput x:Name="BodyInputControl" Grid.Row="3" Margin="0,0,0,5"/>
-        <Button x:Name="SendButton" Grid.Row="4" Content="送信" Width="100" HorizontalAlignment="Right"/>
+        <Button x:Name="SendButton" Grid.Row="4" Content="送信" Width="100" HorizontalAlignment="Right" Click="SendButton_Click"/>
+        <controls:ResponseOutput x:Name="ResponseOutputControl" Grid.Row="5"/>
     </Grid>
 </Window>

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -9,8 +9,45 @@ using System.Windows.Media.Imaging;
 using System.Windows.Navigation;
 using System.Windows.Shapes;
 
+using Controls.UrlInput;
+using Controls.MethodSelecter;
+using Controls.AuthInput;
+using Controls.HeaderInput;
+using Controls.BodyInput;
+using Controls.ResponseOutput;
+using Models;
+using Services;
+
 public partial class MainWindow : Window{
+    private readonly ApiRequestService _service = new ApiRequestService();
+
     public MainWindow(){
         InitializeComponent();
+    }
+
+    private async void SendButton_Click(object sender, RoutedEventArgs e){
+        if(!HeaderInputControl.TryGetHeaders(out var headers, out string hErr)){
+            MessageBox.Show($"Header Error: {hErr}");
+            return;
+        }
+        if(!BodyInputControl.TryGetBody(out var body, out string bErr)){
+            MessageBox.Show($"Body Error: {bErr}");
+            return;
+        }
+
+        ApiSetting setting = new ApiSetting{
+            Url = UrlInputControl.Url,
+            Method = MethodSelecterControl.Method,
+            Headers = headers,
+            Body = body,
+            AuthType = AuthInputControl.AuthType,
+            BearerTokenPath = AuthInputControl.TokenPath
+        };
+
+        var (response, status) = await _service.SendRequestAsync(setting);
+        if(Utils.JsonUtils.TryFormatJson(response, out string formatted, out _))
+            ResponseOutputControl.Text = formatted;
+        else
+            ResponseOutputControl.Text = response;
     }
 }

--- a/Services/ApiRequestService.cs
+++ b/Services/ApiRequestService.cs
@@ -3,6 +3,7 @@ using System.Net.Http;
 using System.Threading.Tasks;
 using Models;
 using System.IO;
+using System.Text.Json;
 
 namespace Services{
     public class ApiRequestService{
@@ -33,11 +34,23 @@ namespace Services{
                 try{
                     HttpResponseMessage res = await client.SendAsync(request);
                     string content = await res.Content.ReadAsStringAsync();
+                    Log(setting, (int)res.StatusCode, content);
                     return (content, (int)res.StatusCode);
                 } catch (Exception ex) {
+                    Log(setting, 0, $"Error: {ex.Message}");
                     return ($"Error: {ex.Message}", 0);
                 }
             }
+        }
+
+        private void Log(ApiSetting setting, int statusCode, string response){
+            Directory.CreateDirectory("api_log");
+            string name = string.IsNullOrWhiteSpace(setting.Name) ? "request" : setting.Name;
+            string file = DateTime.Now.ToString("yyyyMMdd_HHmmss") + $"_{name}.log";
+            string path = Path.Combine("api_log", file);
+            string headers = JsonSerializer.Serialize(setting.Headers);
+            string content = $"URL: {setting.Url}\nMethod: {setting.Method}\nStatus: {statusCode}\nHeaders: {headers}\nBody: {setting.Body}\nResponse: {response}";
+            File.WriteAllText(path, content);
         }
     }
 }


### PR DESCRIPTION
## Summary
- add getter logic to each input control
- add response output control for displaying formatted results
- log requests and responses in `api_log`
- wire up Send button to execute requests

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6884d0178ac88326a5d08f0489c33a86