### PR TITLE
Implement tabbed UI layout

### DIFF
--- a/Controls/ApiRequestTab/ApiRequestTab.xaml
+++ b/Controls/ApiRequestTab/ApiRequestTab.xaml
@@ -1,0 +1,25 @@
+<UserControl x:Class="Controls.ApiRequestTab"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:controls="clr-namespace:Controls"
+    Height="Auto" Width="Auto">
+    <Grid Margin="10">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="*"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="2*"/>
+        </Grid.RowDefinitions>
+        <controls:UrlInput x:Name="UrlInputControl" Grid.Row="0" Margin="0,0,0,5"/>
+        <StackPanel Orientation="Horizontal" Grid.Row="1" Margin="0,0,0,5">
+            <controls:MethodSelecter x:Name="MethodSelecterControl" Width="100"/>
+            <controls:AuthInput x:Name="AuthInputControl" Margin="10,0,0,0"/>
+        </StackPanel>
+        <controls:HeaderInput x:Name="HeaderInputControl" Grid.Row="2" Margin="0,0,0,5"/>
+        <controls:BodyInput x:Name="BodyInputControl" Grid.Row="3" Margin="0,0,0,5"/>
+        <Button x:Name="SendButton" Grid.Row="4" Content="送信" Width="100" HorizontalAlignment="Right" Click="SendButton_Click"/>
+        <controls:ResponseOutput x:Name="ResponseOutputControl" Grid.Row="5"/>
+    </Grid>
+</UserControl>

--- a/Controls/ApiRequestTab/ApiRequestTab.xaml.cs
+++ b/Controls/ApiRequestTab/ApiRequestTab.xaml.cs
@@ -1,0 +1,39 @@
+using System.Windows;
+using System.Windows.Controls;
+using Models;
+using Services;
+
+namespace Controls{
+    public partial class ApiRequestTab : UserControl{
+        private readonly ApiRequestService _service = new ApiRequestService();
+        public ApiRequestTab(){
+            InitializeComponent();
+        }
+
+        private async void SendButton_Click(object sender, RoutedEventArgs e){
+            if(!HeaderInputControl.TryGetHeaders(out var headers, out string hErr)){
+                MessageBox.Show($"Header Error: {hErr}");
+                return;
+            }
+            if(!BodyInputControl.TryGetBody(out var body, out string bErr)){
+                MessageBox.Show($"Body Error: {bErr}");
+                return;
+            }
+
+            ApiSetting setting = new ApiSetting{
+                Url = UrlInputControl.Url,
+                Method = MethodSelecterControl.Method,
+                Headers = headers,
+                Body = body,
+                AuthType = AuthInputControl.AuthType,
+                BearerTokenPath = AuthInputControl.TokenPath
+            };
+
+            var (response, status) = await _service.SendRequestAsync(setting);
+            if(Utils.JsonUtils.TryFormatJson(response, out string formatted, out _))
+                ResponseOutputControl.Text = formatted;
+            else
+                ResponseOutputControl.Text = response;
+        }
+    }
+}

--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -1,28 +1,22 @@
-﻿<Window x:Class="MainWindow"
+<Window x:Class="MainWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         mc:Ignorable="d"
-    xmlns:controls="clr-namespace:Controls"
-        Title="APIテストツール" Height="450" Width="800">
-    <Grid Margin="10">
-        <Grid.RowDefinitions>
-            <RowDefinition Height="Auto"/>
-            <RowDefinition Height="Auto"/>
-            <RowDefinition Height="Auto"/>
-            <RowDefinition Height="*"/>
-            <RowDefinition Height="Auto"/>
-            <RowDefinition Height="2*"/>
-        </Grid.RowDefinitions>
-        <controls:UrlInput x:Name="UrlInputControl" Grid.Row="0" Margin="0,0,0,5"/>
-        <StackPanel Orientation="Horizontal" Grid.Row="1" Margin="0,0,0,5">
-            <controls:MethodSelecter x:Name="MethodSelecterControl" Width="100"/>
-            <controls:AuthInput x:Name="AuthInputControl" Margin="10,0,0,0"/>
-        </StackPanel>
-        <controls:HeaderInput x:Name="HeaderInputControl" Grid.Row="2" Margin="0,0,0,5"/>
-        <controls:BodyInput x:Name="BodyInputControl" Grid.Row="3" Margin="0,0,0,5"/>
-        <Button x:Name="SendButton" Grid.Row="4" Content="送信" Width="100" HorizontalAlignment="Right" Click="SendButton_Click"/>
-        <controls:ResponseOutput x:Name="ResponseOutputControl" Grid.Row="5"/>
-    </Grid>
+        xmlns:controls="clr-namespace:Controls"
+        Title="APIテストツール" Height="600" Width="800">
+    <DockPanel>
+        <Button x:Name="AddTabButton" Content="タブ追加" DockPanel.Dock="Top" Margin="5" Click="AddTabButton_Click"/>
+        <TabControl x:Name="MainTabControl">
+            <TabItem Header="TestAll">
+                <StackPanel Margin="10">
+                    <TextBlock Text="全体実行機能は未実装です。"/>
+                </StackPanel>
+            </TabItem>
+            <TabItem Header="Request1">
+                <controls:ApiRequestTab/>
+            </TabItem>
+        </TabControl>
+    </DockPanel>
 </Window>

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -1,48 +1,21 @@
-﻿using System.Text;
 using System.Windows;
 using System.Windows.Controls;
-using System.Windows.Data;
-using System.Windows.Documents;
-using System.Windows.Input;
-using System.Windows.Media;
-using System.Windows.Media.Imaging;
-using System.Windows.Navigation;
-using System.Windows.Shapes;
-
 using Controls;
-using Models;
-using Services;
 
 public partial class MainWindow : Window{
-    private readonly ApiRequestService _service = new ApiRequestService();
+    private int _tabCount = 1;
 
     public MainWindow(){
         InitializeComponent();
     }
 
-    private async void SendButton_Click(object sender, RoutedEventArgs e){
-        if(!HeaderInputControl.TryGetHeaders(out var headers, out string hErr)){
-            MessageBox.Show($"Header Error: {hErr}");
-            return;
-        }
-        if(!BodyInputControl.TryGetBody(out var body, out string bErr)){
-            MessageBox.Show($"Body Error: {bErr}");
-            return;
-        }
-
-        ApiSetting setting = new ApiSetting{
-            Url = UrlInputControl.Url,
-            Method = MethodSelecterControl.Method,
-            Headers = headers,
-            Body = body,
-            AuthType = AuthInputControl.AuthType,
-            BearerTokenPath = AuthInputControl.TokenPath
+    private void AddTabButton_Click(object sender, RoutedEventArgs e){
+        _tabCount++;
+        TabItem item = new TabItem{
+            Header = $"Request{_tabCount}",
+            Content = new ApiRequestTab()
         };
-
-        var (response, status) = await _service.SendRequestAsync(setting);
-        if(Utils.JsonUtils.TryFormatJson(response, out string formatted, out _))
-            ResponseOutputControl.Text = formatted;
-        else
-            ResponseOutputControl.Text = response;
+        MainTabControl.Items.Add(item);
+        MainTabControl.SelectedItem = item;
     }
 }


### PR DESCRIPTION
## Summary
- add `ApiRequestTab` control to encapsulate single API request UI
- switch `MainWindow` to a tab-based layout and increase window height
- add simple tab creation logic

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6884f12e3c2483269b2b550715204650