### PR TITLE
Improve tab UI and folder selection

### DIFF
--- a/APITestTool.csproj
+++ b/APITestTool.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net9.0-windows</TargetFramework>
+    <TargetFramework>net8.0-windows</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <UseWPF>true</UseWPF>

--- a/Controls/ApiRequestTab/ApiRequestTab.xaml
+++ b/Controls/ApiRequestTab/ApiRequestTab.xaml
@@ -1,0 +1,33 @@
+<UserControl x:Class="Controls.ApiRequestTab"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:controls="clr-namespace:Controls"
+    Height="Auto" Width="Auto">
+    <Grid Margin="10">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="*"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="2*"/>
+        </Grid.RowDefinitions>
+        <StackPanel Orientation="Horizontal" Grid.Row="0" Margin="0,0,0,5">
+            <TextBlock x:Name="NameLabel" Text="Request" VerticalAlignment="Center"/>
+            <Button x:Name="EditNameButton" Content="Edit" Width="40" Margin="5,0,0,0" Click="EditNameButton_Click"/>
+            <TextBox x:Name="NameTextBox" Width="200" Visibility="Collapsed" Margin="5,0,0,0"/>
+        </StackPanel>
+        <TextBox x:Name="MemoTextBox" Grid.Row="1" Height="40" TextWrapping="Wrap" Margin="0,0,0,5"/>
+        <controls:UrlInput x:Name="UrlInputControl" Grid.Row="2" Margin="0,0,0,5"/>
+        <StackPanel Orientation="Horizontal" Grid.Row="3" Margin="0,0,0,5">
+            <controls:MethodSelecter x:Name="MethodSelecterControl" Width="100"/>
+            <controls:AuthInput x:Name="AuthInputControl" Margin="10,0,0,0"/>
+        </StackPanel>
+        <controls:HeaderInput x:Name="HeaderInputControl" Grid.Row="4" Margin="0,0,0,5"/>
+        <controls:BodyInput x:Name="BodyInputControl" Grid.Row="5" Margin="0,0,0,5"/>
+        <Button x:Name="SendButton" Grid.Row="6" Content="送信" Width="100" HorizontalAlignment="Right" Click="SendButton_Click"/>
+        <controls:ResponseOutput x:Name="ResponseOutputControl" Grid.Row="7"/>
+    </Grid>
+</UserControl>

--- a/Controls/ApiRequestTab/ApiRequestTab.xaml.cs
+++ b/Controls/ApiRequestTab/ApiRequestTab.xaml.cs
@@ -1,0 +1,68 @@
+using System.Windows;
+using System.Windows.Controls;
+using System;
+using Models;
+using Services;
+
+namespace Controls{
+    public partial class ApiRequestTab : UserControl{
+        private readonly ApiRequestService _service = new ApiRequestService();
+        private bool _editingName;
+
+        public event Action<string>? NameChanged;
+
+        public ApiRequestTab(){
+            InitializeComponent();
+        }
+
+        private void EditNameButton_Click(object sender, RoutedEventArgs e){
+            if(!_editingName){
+                NameTextBox.Text = NameLabel.Text;
+                NameLabel.Visibility = Visibility.Collapsed;
+                NameTextBox.Visibility = Visibility.Visible;
+                EditNameButton.Content = "Save";
+                _editingName = true;
+            }else{
+                NameLabel.Text = NameTextBox.Text;
+                NameLabel.Visibility = Visibility.Visible;
+                NameTextBox.Visibility = Visibility.Collapsed;
+                EditNameButton.Content = "Edit";
+                NameChanged?.Invoke(NameLabel.Text);
+                _editingName = false;
+            }
+        }
+
+        private async void SendButton_Click(object sender, RoutedEventArgs e){
+            if(!HeaderInputControl.TryGetHeaders(out var headers, out string hErr)){
+                MessageBox.Show($"Header Error: {hErr}");
+                return;
+            }
+            if(!BodyInputControl.TryGetBody(out var body, out string bErr)){
+                MessageBox.Show($"Body Error: {bErr}");
+                return;
+            }
+
+            ApiSetting setting = new ApiSetting{
+                Url = UrlInputControl.Url,
+                Method = MethodSelecterControl.Method,
+                Headers = headers,
+                Body = body,
+                AuthType = AuthInputControl.AuthType,
+                BearerTokenPath = AuthInputControl.TokenPath
+            };
+
+            if(Application.Current.MainWindow is MainWindow main)
+                main.StatusText.Text = "Sending...";
+
+            var (response, status) = await _service.SendRequestAsync(setting);
+
+            if(Utils.JsonUtils.TryFormatJson(response, out string formatted, out _))
+                ResponseOutputControl.Text = formatted;
+            else
+                ResponseOutputControl.Text = response;
+
+            if(Application.Current.MainWindow is MainWindow main2)
+                main2.StatusText.Text = $"Status: {status}";
+        }
+    }
+}

--- a/Controls/BodyInput/BodyInput.xaml
+++ b/Controls/BodyInput/BodyInput.xaml
@@ -5,7 +5,7 @@
     <Grid Margin="10">
         <StackPanel>
             <TextBlock Text="Body:"/>
-            <TextBox x:Name="BodyTextBox" Height="100" AcceptsReturn="True" VerticalScrollBarVisibility="Auto"/>
+            <TextBox x:Name="BodyTextBox" Height="100" AcceptsReturn="True" VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Auto"/>
         </StackPanel>
     </Grid>
 </UserControl>

--- a/Controls/HeaderInput/HeaderInput.xaml
+++ b/Controls/HeaderInput/HeaderInput.xaml
@@ -3,9 +3,14 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     Height="Auto" Width="Auto">
     <Grid Margin="10">
-        <StackPanel Orientation="Horizontal">
-            <TextBlock Text="Headers:" Width="60"/>
-            <TextBox x:Name="HeadersTextBox" Width="400" ToolTip="JSON形式で入力"/>
+        <StackPanel>
+            <TextBlock Text="Headers:" Margin="0,0,0,5"/>
+            <DataGrid x:Name="HeaderGrid" AutoGenerateColumns="False" CanUserAddRows="True" Height="100" HeadersVisibility="Column">
+                <DataGrid.Columns>
+                    <DataGridTextColumn Header="Name" Binding="{Binding Key}" Width="*"/>
+                    <DataGridTextColumn Header="Value" Binding="{Binding Value}" Width="2*"/>
+                </DataGrid.Columns>
+            </DataGrid>
         </StackPanel>
     </Grid>
 </UserControl>

--- a/Controls/HeaderInput/HeaderInput.xaml.cs
+++ b/Controls/HeaderInput/HeaderInput.xaml.cs
@@ -1,26 +1,34 @@
 using System.Collections.Generic;
-using System.Text.Json;
+using System.Collections.ObjectModel;
 using System.Windows.Controls;
-using Utils;
 
 namespace Controls{
     public partial class HeaderInput : UserControl{
+        public class HeaderEntry{
+            public string Key{ get; set; } = string.Empty;
+            public string Value{ get; set; } = string.Empty;
+        }
+
+        public ObservableCollection<HeaderEntry> Headers{ get; } = new ObservableCollection<HeaderEntry>();
+
         public HeaderInput(){
             InitializeComponent();
+            HeaderGrid.ItemsSource = Headers;
+            Headers.Add(new HeaderEntry());
         }
+
         public bool TryGetHeaders(out Dictionary<string, string> headers, out string error){
             headers = new Dictionary<string, string>();
-            error = "";
-            if(string.IsNullOrWhiteSpace(HeadersTextBox.Text)) return true;
-            if(!JsonUtils.TryFormatJson(HeadersTextBox.Text, out string formatted, out error)) return false;
-            try{
-                headers = JsonSerializer.Deserialize<Dictionary<string, string>>(formatted) ?? new Dictionary<string, string>();
-                HeadersTextBox.Text = formatted;
-                return true;
-            }catch(JsonException ex){
-                error = ex.Message;
-                return false;
+            error = string.Empty;
+            foreach(var h in Headers){
+                if(string.IsNullOrWhiteSpace(h.Key)) continue;
+                if(headers.ContainsKey(h.Key)){
+                    error = $"Duplicate header: {h.Key}";
+                    return false;
+                }
+                headers[h.Key] = h.Value ?? string.Empty;
             }
+            return true;
         }
     }
 }

--- a/Controls/ResponseOutput/ResponseOutput.xaml
+++ b/Controls/ResponseOutput/ResponseOutput.xaml
@@ -5,7 +5,7 @@
     <Grid Margin="10">
         <StackPanel>
             <TextBlock Text="Response:"/>
-            <TextBox x:Name="ResponseTextBox" Height="150" AcceptsReturn="True" VerticalScrollBarVisibility="Auto" IsReadOnly="True" TextWrapping="Wrap"/>
+            <TextBox x:Name="ResponseTextBox" Height="150" AcceptsReturn="True" VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Auto" IsReadOnly="True" TextWrapping="Wrap"/>
         </StackPanel>
     </Grid>
 </UserControl>

--- a/Controls/TestAllTab/TestAllTab.xaml
+++ b/Controls/TestAllTab/TestAllTab.xaml
@@ -1,0 +1,27 @@
+<UserControl x:Class="Controls.TestAllTab"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    Height="Auto" Width="Auto">
+    <Grid Margin="10">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="*"/>
+            <RowDefinition Height="Auto"/>
+        </Grid.RowDefinitions>
+        <StackPanel Orientation="Horizontal" Grid.Row="0" Margin="0,0,0,5">
+            <Button x:Name="RefreshButton" Content="Refresh" Click="RefreshButton_Click"/>
+        </StackPanel>
+        <Grid Grid.Row="1">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="*"/>
+                <ColumnDefinition Width="200"/>
+            </Grid.ColumnDefinitions>
+            <ListBox x:Name="FileList" Grid.Column="0"/>
+            <ListBox x:Name="FolderList" Grid.Column="1" SelectionChanged="FolderList_SelectionChanged" ScrollViewer.VerticalScrollBarVisibility="Auto"/>
+        </Grid>
+        <StackPanel Orientation="Horizontal" Grid.Row="2" HorizontalAlignment="Right" Margin="0,5,0,0">
+            <Button x:Name="TestAllButton" Content="TestAll" Width="100" Click="TestAllButton_Click"/>
+            <TextBlock x:Name="ResultText" Margin="10,3,0,0"/>
+        </StackPanel>
+    </Grid>
+</UserControl>

--- a/Controls/TestAllTab/TestAllTab.xaml.cs
+++ b/Controls/TestAllTab/TestAllTab.xaml.cs
@@ -1,0 +1,64 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Windows;
+using System.Windows.Controls;
+using Models;
+using Services;
+
+namespace Controls{
+    public partial class TestAllTab : UserControl{
+        private readonly ApiRequestService _service = new ApiRequestService();
+        public TestAllTab(){
+            InitializeComponent();
+            LoadFolders();
+        }
+
+        private void LoadFolders(){
+            Directory.CreateDirectory("api");
+            FolderList.ItemsSource = Directory.GetDirectories("api").Select(Path.GetFileName);
+        }
+
+        private void RefreshButton_Click(object sender, RoutedEventArgs e){
+            LoadFolders();
+        }
+        private void FolderList_SelectionChanged(object sender, SelectionChangedEventArgs e){
+            FileList.ItemsSource = null;
+            if(FolderList.SelectedItem == null) return;
+            string folder = Path.Combine("api", FolderList.SelectedItem.ToString()!);
+            var files = Directory.GetFiles(folder, "*.json").Select(Path.GetFileName);
+            FileList.ItemsSource = files;
+        }
+
+        private async void TestAllButton_Click(object sender, RoutedEventArgs e){
+            if(FolderList.SelectedItem == null) return;
+            string folder = Path.Combine("api", FolderList.SelectedItem.ToString()!);
+            var files = Directory.GetFiles(folder, "*.json");
+            int total = files.Length;
+            int success = 0, fail = 0;
+
+            if(Application.Current.MainWindow is MainWindow main)
+                main.StatusText.Text = "Running...";
+
+            foreach(var file in files){
+                try{
+                    string json = File.ReadAllText(file);
+                    ApiSetting? setting = System.Text.Json.JsonSerializer.Deserialize<ApiSetting>(json);
+                    if(setting == null){
+                        fail++;
+                        continue;
+                    }
+                    var (_, status) = await _service.SendRequestAsync(setting);
+                    if(status >= 200 && status < 300) success++; else fail++;
+                }catch(Exception){
+                    fail++;
+                }
+            }
+
+            if(Application.Current.MainWindow is MainWindow main2)
+                main2.StatusText.Text = "Ready";
+
+            ResultText.Text = $"Total:{total} Success:{success} Fail:{fail}";
+        }
+    }
+}

--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -1,28 +1,29 @@
-﻿<Window x:Class="MainWindow"
+<Window x:Class="MainWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        xmlns:controls="clr-namespace:Controls"
         mc:Ignorable="d"
-    xmlns:controls="clr-namespace:Controls"
-        Title="APIテストツール" Height="450" Width="800">
-    <Grid Margin="10">
-        <Grid.RowDefinitions>
-            <RowDefinition Height="Auto"/>
-            <RowDefinition Height="Auto"/>
-            <RowDefinition Height="Auto"/>
-            <RowDefinition Height="*"/>
-            <RowDefinition Height="Auto"/>
-            <RowDefinition Height="2*"/>
-        </Grid.RowDefinitions>
-        <controls:UrlInput x:Name="UrlInputControl" Grid.Row="0" Margin="0,0,0,5"/>
-        <StackPanel Orientation="Horizontal" Grid.Row="1" Margin="0,0,0,5">
-            <controls:MethodSelecter x:Name="MethodSelecterControl" Width="100"/>
-            <controls:AuthInput x:Name="AuthInputControl" Margin="10,0,0,0"/>
-        </StackPanel>
-        <controls:HeaderInput x:Name="HeaderInputControl" Grid.Row="2" Margin="0,0,0,5"/>
-        <controls:BodyInput x:Name="BodyInputControl" Grid.Row="3" Margin="0,0,0,5"/>
-        <Button x:Name="SendButton" Grid.Row="4" Content="送信" Width="100" HorizontalAlignment="Right" Click="SendButton_Click"/>
-        <controls:ResponseOutput x:Name="ResponseOutputControl" Grid.Row="5"/>
-    </Grid>
+        Title="APIテストツール" Height="700" Width="900">
+    <DockPanel>
+        <Menu DockPanel.Dock="Top">
+            <MenuItem Header="_File">
+                <MenuItem Header="New Tab" Click="MenuAddTab_Click"/>
+                <MenuItem Header="Exit" Click="MenuExit_Click"/>
+            </MenuItem>
+            <MenuItem Header="_Run">
+                <MenuItem Header="Run All" Click="MenuRunAll_Click"/>
+            </MenuItem>
+        </Menu>
+        <StatusBar DockPanel.Dock="Bottom">
+            <TextBlock x:Name="StatusText" Text="Ready"/>
+        </StatusBar>
+        <TabControl x:Name="MainTabControl" SelectionChanged="MainTabControl_SelectionChanged">
+            <TabItem Header="TestAll">
+                <controls:TestAllTab/>
+            </TabItem>
+            <TabItem x:Name="AddTabItem" Header="+"/>
+        </TabControl>
+    </DockPanel>
 </Window>

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -1,48 +1,47 @@
-﻿using System.Text;
 using System.Windows;
 using System.Windows.Controls;
-using System.Windows.Data;
-using System.Windows.Documents;
-using System.Windows.Input;
-using System.Windows.Media;
-using System.Windows.Media.Imaging;
-using System.Windows.Navigation;
-using System.Windows.Shapes;
-
 using Controls;
-using Models;
-using Services;
 
 public partial class MainWindow : Window{
-    private readonly ApiRequestService _service = new ApiRequestService();
+    private int _tabCount = 0;
 
     public MainWindow(){
         InitializeComponent();
+        Loaded += (_, __) => AddRequestTab();
     }
 
-    private async void SendButton_Click(object sender, RoutedEventArgs e){
-        if(!HeaderInputControl.TryGetHeaders(out var headers, out string hErr)){
-            MessageBox.Show($"Header Error: {hErr}");
-            return;
-        }
-        if(!BodyInputControl.TryGetBody(out var body, out string bErr)){
-            MessageBox.Show($"Body Error: {bErr}");
-            return;
-        }
+    private void MenuAddTab_Click(object sender, RoutedEventArgs e){
+        AddRequestTab();
+    }
 
-        ApiSetting setting = new ApiSetting{
-            Url = UrlInputControl.Url,
-            Method = MethodSelecterControl.Method,
-            Headers = headers,
-            Body = body,
-            AuthType = AuthInputControl.AuthType,
-            BearerTokenPath = AuthInputControl.TokenPath
-        };
+    private void MenuExit_Click(object sender, RoutedEventArgs e){
+        Close();
+    }
 
-        var (response, status) = await _service.SendRequestAsync(setting);
-        if(Utils.JsonUtils.TryFormatJson(response, out string formatted, out _))
-            ResponseOutputControl.Text = formatted;
-        else
-            ResponseOutputControl.Text = response;
+    private void MenuRunAll_Click(object sender, RoutedEventArgs e){
+        MainTabControl.SelectedIndex = 0; // TestAll tab assumed first
+    }
+
+    private void MainTabControl_SelectionChanged(object sender, SelectionChangedEventArgs e){
+        if(MainTabControl.SelectedItem == AddTabItem){
+            AddRequestTab();
+        }
+    }
+
+    private void AddRequestTab(){
+        _tabCount++;
+        TabItem item = new TabItem();
+        DockPanel header = new DockPanel();
+        TextBlock text = new TextBlock{ Text = $"Request{_tabCount}", Margin = new Thickness(0,0,5,0) };
+        Button close = new Button{ Content = "x", Padding = new Thickness(0), Width = 16, Height = 16 };
+        close.Click += (s, e) => MainTabControl.Items.Remove(item);
+        header.Children.Add(text);
+        header.Children.Add(close);
+        item.Header = header;
+        var tab = new ApiRequestTab();
+        tab.NameChanged += name => text.Text = name;
+        item.Content = tab;
+        MainTabControl.Items.Insert(MainTabControl.Items.Count - 1, item);
+        MainTabControl.SelectedItem = item;
     }
 }


### PR DESCRIPTION
## Summary
- update project to target .NET 8
- add editable name and memo fields in `ApiRequestTab`
- redesign headers input as a table with multiple entries
- make body and response text boxes scrollable
- rework `TestAllTab` to select folders from a list
- add dynamic request tab creation on window load and larger default window size

## Testing
- `dotnet build` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_6884f12e3c2483269b2b550715204650