### PR TITLE
Unify control components

### DIFF
--- a/Controls/APINameInput/APINameInput.xaml
+++ b/Controls/APINameInput/APINameInput.xaml
@@ -2,9 +2,11 @@
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     Height="Auto" Width="Auto">
-        <StackPanel Orientation="Horizontal" Margin="0,0,0,5">
+    <Grid Margin="10">
+        <StackPanel Orientation="Horizontal">
             <TextBlock x:Name="NameLabel" Text="Request" VerticalAlignment="Center"/>
             <Button x:Name="EditNameButton" Content="Edit" Width="40" Margin="5,0,0,0" Click="EditNameButton_Click"/>
             <TextBox x:Name="NameTextBox" Width="200" Visibility="Collapsed" Margin="5,0,0,0"/>
         </StackPanel>
+    </Grid>
 </UserControl>

--- a/Controls/APINameInput/APINameInput.xaml.cs
+++ b/Controls/APINameInput/APINameInput.xaml.cs
@@ -11,10 +11,15 @@ namespace Controls{
         public APINameInput(){
             InitializeComponent();
         }
-        
+
         public string APIName{
             get => ctrlNameTextBox.Text;
             set => ctrlNameTextBox.Text = value;
+        }
+
+        public string Text{
+            get => APIName;
+            set => APIName = value;
         }
         
         private void EditNameButton_Click(object sender, RoutedEventArgs e){

--- a/Controls/AuthInput/AuthInput.xaml.cs
+++ b/Controls/AuthInput/AuthInput.xaml.cs
@@ -13,5 +13,10 @@ namespace Controls{
             get => TokenPathTextBox.Text;
             set => TokenPathTextBox.Text = value;
         }
+
+        public string Text{
+            get => TokenPath;
+            set => TokenPath = value;
+        }
     }
 }

--- a/Controls/BodyInput/BodyInput.xaml.cs
+++ b/Controls/BodyInput/BodyInput.xaml.cs
@@ -6,6 +6,10 @@ namespace Controls{
         public BodyInput(){
             InitializeComponent();
         }
+        public string Text{
+            get => BodyTextBox.Text;
+            set => BodyTextBox.Text = value;
+        }
         public bool TryGetBody(out string body, out string error){
             body = string.Empty;
             error = string.Empty;

--- a/Controls/MethodSelecter/MethodSelecter.xaml.cs
+++ b/Controls/MethodSelecter/MethodSelecter.xaml.cs
@@ -9,5 +9,7 @@ namespace Controls{
         public string Method{
             get => ((ComboBoxItem)MethodComboBox.SelectedItem)?.Content?.ToString() ?? "GET";
         }
+
+        public string Text => Method;
     }
 }

--- a/Controls/UrlInput/UrlInput.xaml.cs
+++ b/Controls/UrlInput/UrlInput.xaml.cs
@@ -9,5 +9,10 @@ namespace Controls{
             get => UrlTextBox.Text;
             set => UrlTextBox.Text = value;
         }
+
+        public string Text{
+            get => Url;
+            set => Url = value;
+        }
     }
 }


### PR DESCRIPTION
## Summary
- unify layout for `APINameInput`
- expose `Text` property on each control for consistent access

## Testing
- `dotnet build` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_68861a767688832681d52ea7ca1a97e7